### PR TITLE
Compatible with Gnome 3.30.2.

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -46,7 +46,7 @@ function getWindowsOnActiveWorkspace() {
     let windows = [];
     let windowActors = global.get_window_actors();
 
-    let curWorkSpace = global.screen.get_active_workspace();
+    let curWorkSpace = global.workspaceManager.get_active_workspace();
 
     for (let i = 0; i < windowActors.length; i++) {
         let win = windowActors[i].meta_window;
@@ -136,7 +136,7 @@ function expandVertically(y, left, right, miny, maxy, windows) {
  * both vertically and horizontally. The expnasion that results
  * in closer to 1 aspect ratio is selected. 
  */
-function snapToNeighbors(display, screen, window, binding) {
+function snapToNeighbors(display, window, binding) {
     // Unmaximize first
     if (window.maximized_horizontally || window.maximizedVertically)
         window.unmaximize(Meta.MaximizeFlags.HORIZONTAL | Meta.MaximizeFlags.VERTICAL);

--- a/metadata.json
+++ b/metadata.json
@@ -4,5 +4,5 @@
     "uuid": "gssnaptoneighbors@tpyl.github.io",
     "settings-schema": "org.gnome.shell.extensions.snaptoneighbors",
     "url": "https://github.com/tpyl/gssnaptoneighbors",
-    "shell-version": ["3.28.2"]
+    "shell-version": ["3.30.2"]
 }


### PR DESCRIPTION
No idea whether it works with multiple displays.

Using just the changes described in https://github.com/tpyl/gssnaptoneighbors/issues/4.